### PR TITLE
Get current workers from Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "amqp-stats": "~0.0.14",
     "async": "~2.1.4",
+    "bluebird": "^3.4.7",
     "coffee-script": "~1.12.2",
     "commander": "~2.9.0",
     "debug": "~2.6.0",

--- a/spec/mocks.coffee
+++ b/spec/mocks.coffee
@@ -34,6 +34,30 @@ exports.Heroku =
     debug 'registered Heroku', payload
     return scope
 
+  setCurrentWorkers: (app, workers) ->
+    return new NoMock if not exports.enable
+
+    formation = []
+    for name, qty of workers
+      f =
+        type: name
+        quantity: qty
+        app:
+          name: app
+          id: 'app-uuid'
+        id: 'process-uuid'
+        size: 'Free'
+        created_at: '2015-06-23T07:00:27Z'
+        updated_at: '2017-02-21T18:56:58Z'
+        command: 'node ....'
+      formation.push f
+
+    scope = require('nock')('https://api.heroku.com')
+      .get("/apps/#{app}/formation")
+      .reply(200, formation)
+    debug 'registered Heroku.setCurrentWorkers', workers
+    return scope
+
 exports.RabbitMQ =
   setQueues: (overrides={}) ->
     return new NoMock if not exports.enable

--- a/spec/statuspage.coffee
+++ b/spec/statuspage.coffee
@@ -38,6 +38,7 @@ describe 'Statuspage.io metrics', ->
     describe 'when state changes', ->
       it 'should report pending jobs', (done) ->
         mocks.RabbitMQ.setQueues { 'myrole.IN': { 'messages': 1000 } }
+        mocks.Heroku.setCurrentWorkers 'guv-test', { 'web': 0 }
         postMetrics = mocks.StatusPageIO.expectMetric cfg['*'].statuspage, cfg.my.metric, 1000
         setWorkers = mocks.Heroku.expectWorkers 'guv-test', { 'web': cfg.my.maximum }
 
@@ -49,7 +50,6 @@ describe 'Statuspage.io metrics', ->
             postMetrics.done()
             setWorkers.done()
             done()
-          , 0
+          , 500
         governor.start()
-
 

--- a/spec/statuspage.coffee
+++ b/spec/statuspage.coffee
@@ -27,7 +27,8 @@ describe 'Statuspage.io metrics', ->
       process.env['STATUSPAGE_API_TOKEN'] = 'statuspage-api-token-444'
       governor = new guv.governor.Governor cfg
       guv.statuspage.register governor, cfg
-      chai.expect(cfg['*'].broker).to.include 'amqp://'
+      chai.expect(cfg['*'].broker, 'broker url').to.exist
+      chai.expect(cfg['*'].broker, 'broker url').to.include 'amqp://'
       done()
 
     afterEach (done) ->

--- a/src/governor.coffee
+++ b/src/governor.coffee
@@ -76,7 +76,7 @@ objectValues = (obj) ->
   return vals
 
 historyStateValid = (s) ->
-  return s.error or (s.estimated_workers? and s.current_workers?)
+  return s.error or s.estimated_workers?
 historyEntryValid = (r) ->
   return objectValues(r).every historyStateValid
 historyValid = (h) ->

--- a/src/governor.coffee
+++ b/src/governor.coffee
@@ -4,6 +4,7 @@
 
 debug = require('debug')('guv:governor')
 { EventEmitter } = require 'events'
+bluebird = require 'bluebird'
 
 heroku = require './heroku'
 rabbitmq = require './rabbitmq'
@@ -16,7 +17,11 @@ extractHistory = (history, rolename, key) ->
     predictions.push state[rolename][key]
   return predictions
 
-nextState = (cfg, window, queues, queueDetails) ->
+nextState = (cfg, window, queues, queueDetails, currentWorkers) ->
+
+  workersObject = {}
+  for w in currentWorkers
+    workersObject[w.role] = w
 
   state = {}
   # TODO: store timestamps?
@@ -36,8 +41,8 @@ nextState = (cfg, window, queues, queueDetails) ->
       s.error = new Error "Could not get data for queue: #{role.queue}"
     else
       history = extractHistory window, name, 'estimated_workers'
-      currentWorkers = extractHistory(window, name, 'current_workers')[history.length-1]
-      s.previous_workers = currentWorkers
+      currentWorkers =  # Heroku
+      s.previous_workers = workersObject[role.worker].quantity
       workers = scale.scaleWithHistory role, name, history, currentWorkers, s.current_jobs
       s.estimated_workers = workers.estimate
       if workers.next?
@@ -110,19 +115,31 @@ class Governor extends EventEmitter
     @history = @history.slice Math.max(@history.length-@historysize, 0)
     debug 'history length', @history.length
 
-  nextState: (err, queues, details) ->
-    state = nextState @config, @history, queues, details
+  nextState: (queues, details, workers) ->
+    state = nextState @config, @history, queues, details, workers
     history = @history.concat [ state ]
     @updateHistory history
     return state
 
   runOnceInternal: (callback) ->
-    try
-      rabbitmq.getStats @config['*'], (err, queues, details) =>
-        state = @nextState err, queues, details
-        realizeState @config, state, callback
-    catch e
-      return callback e
+    getQueues = (mainConfig) ->
+      bluebird.promisify(rabbitmq.getStats, multiArgs: true)(mainConfig)
+      .then (results) ->
+        r =
+          queues: results[0]
+          details: results[1]
+        return Promise.resolve r
+
+    getWorkers = bluebird.promisify heroku.getWorkers
+
+    bluebird.props(
+      rabbitmq: getQueues @config['*']
+      workers: getWorkers @config
+    ).then (current) =>
+      state = @nextState current.rabbitmq.queues, current.rabbitmq.details, current.workers
+      return bluebird.promisify(realizeState)(@config, state)
+    .asCallback callback
+    return null
 
   runOnce: (callback) ->
     @runOnceInternal (err, state) =>


### PR DESCRIPTION
Previously we'd *assume* that the number current workers is what it was last changed to by guv, as stored in the history. This is not generally right. For instance when we first start, we don't have such a value, and we won't have it until we make a scaling decision. Furthermore it is possible for other things than guv to go on change something, so even after having made a scaling decision we can go out of sync.
The canonical answer can be had by asking Heroku via the API. This doubles the number of requests we make per app. Which is normally not a problem, but for accounts which manage many apps this may cause to go over quota (since API quotas are per account).