### PR TITLE
Improve New Relic Insights downloading

### DIFF
--- a/src/insights-download-timeperiod.coffee
+++ b/src/insights-download-timeperiod.coffee
@@ -49,7 +49,7 @@ executeDay = (day, args, callback) ->
 executeOverDays = (args, callback) ->
   days = daysInPeriod args.start, args.end
 
-  async.mapSeries days, (d, cb) ->
+  async.mapLimit days, 5, (d, cb) ->
     executeDay d, args, cb
   , callback
 

--- a/src/insights-download-timeperiod.coffee
+++ b/src/insights-download-timeperiod.coffee
@@ -1,0 +1,19 @@
+
+'2017-03-01'
+
+fs = require 'fs'
+{ spawn } = require 'child_process'
+
+haveData = (file, callback) ->
+  fs.exists file, (exists) ->
+    return callback null, false if not exists
+    fs.stat file, (err, stat) ->
+      return callback err if err
+      hasData = stat.size > 1
+      return callback null, hasData 
+
+main = () ->
+  haveData 'the-grid-api-march18.json', (err, data) ->
+    console.log 'err', err, data
+
+main() if not module.parent 

--- a/src/insights-download-timeperiod.coffee
+++ b/src/insights-download-timeperiod.coffee
@@ -2,7 +2,17 @@
 '2017-03-01'
 
 fs = require 'fs'
-{ spawn } = require 'child_process'
+async = require 'async'
+{ exec } = require 'child_process'
+
+# inclusive. [start, end]
+daysInPeriod = (start, end) ->
+  days = [ ]
+  current = new Date start
+  while current < end
+    days.push current
+    current = new Date(current.setDate(current.getDate() + 1))
+  return days
 
 haveData = (file, callback) ->
   fs.exists file, (exists) ->
@@ -12,8 +22,68 @@ haveData = (file, callback) ->
       hasData = stat.size > 1
       return callback null, hasData 
 
+dateOnlyString = (date) ->
+  return date.toISOString().split('T')[0]
+
+# never returns Error, instead puts them as .error in returned data
+executeDay = (day, args, callback) ->
+  date = dateOnlyString day
+  file = "#{args.prefix}#{date}#{args.suffix}"
+  haveData file, (err, alreadyDone) ->
+    return callback null, { file: file, error: err, status: 'failed when checking file'  } if err
+    if alreadyDone
+      console.log 'SKIP', file
+      return callback null, { file: file, status: 'skipped, already done' }
+    else
+      cmd = args.command.replace '#DATE', date
+      cmd += " > #{file}"
+      options =
+        shell: true
+      console.log '$', cmd
+      exec cmd, options, (err, stdout, stderr) ->
+        status = if err then "FAILED, #{stderr}" else 'SUCCESS'
+        console.log '!', status
+        return callback null, { file: file, error: err, stdout: stdout, stderr: stderr, status: status }
+
+# returns array of an object describing. If has .error, then was a failure
+executeOverDays = (args, callback) ->
+  days = daysInPeriod args.start, args.end
+
+  async.mapSeries days, (d, cb) ->
+    executeDay d, args, cb
+  , callback
+
+parse = (args) ->
+  program = require 'commander'
+  program
+    .option('--prefix <PREFIX>', 'Prefix for all files', String, '')
+    .option('--suffix <SUFFIX>', 'Suffic for all files', String, '')
+    .option('--command <COMMAND>', 'Command to execute for each day.', String, '')
+    .option('--start <DATE>', 'Start time of period to run', String, '')
+    .option('--end <DATE>', 'End time of period to run', String, 'now')
+    .parse(args)
+
+normalize = (args) ->
+  throw new Error "--command must be specified" if not args.command
+  throw new Error "--start must be specified" if not args.start
+  throw new Error "--end must be specified" if not args.end
+
+  args.start = new Date args.start
+  args.end = new Date args.end
+
+  return args
+
 main = () ->
-  haveData 'the-grid-api-march18.json', (err, data) ->
-    console.log 'err', err, data
+  #haveData 'the-grid-api-march18.json', (err, data) ->
+  #  console.log 'err', err, data
+  args = parse process.argv
+  args = normalize args
+
+  executeOverDays args, (err, results) ->
+    failures = results.filter (r) -> r.error
+    exitCode = failures.length
+    if exitCode
+      console.log failures
+    process.exit exitCode
 
 main() if not module.parent 

--- a/src/insights-download-timeperiod.coffee
+++ b/src/insights-download-timeperiod.coffee
@@ -20,7 +20,7 @@ haveData = (file, callback) ->
     fs.stat file, (err, stat) ->
       return callback err if err
       hasData = stat.size > 1
-      return callback null, hasData 
+      return callback null, hasData
 
 dateOnlyString = (date) ->
   return date.toISOString().split('T')[0]
@@ -86,4 +86,4 @@ main = () ->
       console.log failures
     process.exit exitCode
 
-main() if not module.parent 
+main() if not module.parent

--- a/src/insights.coffee
+++ b/src/insights.coffee
@@ -32,7 +32,7 @@ getScaleEventsChunk = (insights, start, end, callback) ->
 
     return callback new Error 'Number of events for interval hit max limit' if body.performanceStats.matchCount >= limit
     results = body.results[0].events
-    return callback new Error 'No results returned' if not results
+    return callback new Error 'No results returned' if not results? # empty array is fine though
 
     return callback null, results
 
@@ -56,7 +56,7 @@ getScaleEvents = (options, callback) ->
 
   debug "Executing #{queries.length} over #{options.period} days"
   throw new Error "Extremely high number of queries needed, over 3k: #{queries.length}" if queries.length > 3000
-  async.mapLimit queries, 20, getChunk, (err, chunks) ->
+  async.mapLimit queries, 10, getChunk, (err, chunks) ->
     return callback err if err
 
     # flatten list

--- a/src/insights.coffee
+++ b/src/insights.coffee
@@ -20,12 +20,13 @@ getTimeIntervals = (start, end, intervalMinutes) ->
       end: new Date(e)
   return intervals
 
-getScaleEventsChunk = (insights, start, end, callback) ->
+getScaleEventsChunk = (insights, start, end, app, callback) ->
   start = start.toISOString()
   end = end.toISOString()
 
   limit = 999
   query = "SELECT jobs,workers,drainrate,fillrate,consumers,role,app,timestamp from GuvScaled SINCE '#{start}' UNTIL '#{end}' LIMIT #{limit}"
+  query += "WHERE app = '#{app}'" if app
   insights.query query, (err, body) ->
     return callback err if err
     return callback new Error "#{body.error}" if body.error
@@ -45,14 +46,13 @@ getScaleEvents = (options, callback) ->
 
   # build subqueries
   queries = []
-  end = new Date() # TODO: make configurable?
-  start = new Date(end)
-  start.setTime(start.getTime()-options.period*24*60*60*1000)
+  end = options.end
+  start = new Date (end.getTime()-options.period*24*60*60*1000)
   queries = getTimeIntervals start, end, options.queryInterval
 
   # execute queries
   getChunk = (period, cb) ->
-    return getScaleEventsChunk insights, period.start, period.end, cb
+    return getScaleEventsChunk insights, period.start, period.end, options.app, cb
 
   debug "Executing #{queries.length} over #{options.period} days"
   throw new Error "Extremely high number of queries needed, over 3k: #{queries.length}" if queries.length > 3000
@@ -75,15 +75,19 @@ parse = (args) ->
   program
     .option('--query-key <hostname>', 'Query Key to access New Relic Insights API', String, '')
     .option('--account-id <port>', 'Account ID used to access New Relic Insights API', String, '')
-    #.option('--app <app>', 'App name in New Relic. Can be specified multiple times', addApp, [])
+    .option('--app <app>', 'App name in New Relic to query for.', String, '')
     .option('--period <days>', 'Number of days to get data for', Number, 7)
+    .option('--end <DATETIME>', 'End time of queried period.', String, 'now')
     .option('--query-interval <minutes>', 'How big chucks to request at a time', Number, 30)
     .parse(args)
 
 normalize = (options) ->
   options.accountId = process.env.NEW_RELIC_ACCOUNT_ID if not options.accountId
   options.queryKey = process.env.NEW_RELIC_QUERY_KEY if not options.queryKey
-  options.app = [ options.app ] if typeof options.app == 'string'
+  if options.end == 'now' or not options.end
+    options.end = new Date()
+  else
+    options.end = new Date options.end
   return options
 
 exports.main = main = () ->

--- a/src/insights.coffee
+++ b/src/insights.coffee
@@ -28,6 +28,7 @@ getScaleEventsChunk = (insights, start, end, callback) ->
   query = "SELECT jobs,workers,drainrate,fillrate,consumers,role,app,timestamp from GuvScaled SINCE '#{start}' UNTIL '#{end}' LIMIT #{limit}"
   insights.query query, (err, body) ->
     return callback err if err
+    return callback new Error "#{body.error}" if body.error
 
     return callback new Error 'Number of events for interval hit max limit' if body.performanceStats.matchCount >= limit
     results = body.results[0].events

--- a/src/insights.coffee
+++ b/src/insights.coffee
@@ -24,7 +24,7 @@ getScaleEventsChunk = (insights, start, end, callback) ->
   end = end.toISOString()
 
   limit = 999
-  query = "SELECT role,jobs,workers,app from GuvScaled SINCE '#{start}' UNTIL '#{end}' LIMIT #{limit}"
+  query = "SELECT jobs,workers,drainrate,fillrate,consumers,role,app,timestamp from GuvScaled SINCE '#{start}' UNTIL '#{end}' LIMIT #{limit}"
   insights.query query, (err, body) ->
     return callback err if err
 


### PR DESCRIPTION
For mass-downloading of event we not only need to work-around their arbitrary 999 row limit, but also handle that the API regularly fails with an error like `Failure: No available Dirac connections, try again later`