### PR TITLE
Fix config issue when multiple apps have roles with same name

### DIFF
--- a/spec/configs.yaml
+++ b/spec/configs.yaml
@@ -82,3 +82,22 @@
     extrarole: { deadline: 330.33, extrakey: 25 }
   valid: true
   validationOptions: '--allow-key extrakey'
+-
+  name: 'differing role vs worker'
+  input: |
+    '*':
+      boot: 20
+      app: imgflo
+      min: 2
+      max: 10
+    processing: { d: 6.0, p: 1.0, queue: 'imgflo_worker.IN', worker: 'my-process-name' }
+  config:
+   "*":
+    app: imgflo
+    boot: 20.0
+   processing:
+    deadline: 6.0
+    processing: 1.0
+    worker: 'my-process-name'
+    queue: imgflo_worker.IN
+  valid: true

--- a/spec/governor.coffee
+++ b/spec/governor.coffee
@@ -126,6 +126,52 @@ describe 'Governor', ->
         async.mapSeries series, iteration, (err) ->
           return done err
 
+  # Complicated config
+  describe 'complicated config', ->
+    c = \
+    """
+    '*': { app: 'guv-test' }
+    my: { queue: 'myrole.IN', worker: web, minimum: 0, max: 1 }
+    ours: { queue: 'ours.IN', worker: web, minimum: 1, max: 1, app: 'other' }
+    """
+    cfg = guv.config.parse c
+    beforeEach (done) ->
+      governor = new guv.governor.Governor cfg
+      done()
+
+    beforeEach (done) ->
+      governor.stop()
+      done()
+
+    describe 'no messages in queue', ->
+      it 'should scale to minimum', (done) ->
+        mocks.Heroku.setCurrentWorkers 'guv-test', { web: 1 }
+        mocks.Heroku.setCurrentWorkers 'other', { web: 2 }
+        mocks.RabbitMQ.setQueues
+          'myrole.IN':
+            'messages': 0
+          'ours.IN':
+            'messages': 0
+        setWorkers1 = mocks.Heroku.expectWorkers 'guv-test',
+          'web': cfg.my.minimum
+
+        setWorkers2 = mocks.Heroku.expectWorkers 'other',
+          'web': cfg.ours.minimum
+
+        governor.once 'error', (err) ->
+          chai.expect(err).to.not.exist
+
+        governor.once 'state', (state) ->
+          chai.expect(state).to.include.keys 'my'
+          chai.expect(state).to.include.keys 'ours'
+          chai.expect(state.my.current_jobs).to.equal 0
+          chai.expect(state.my.new_workers).to.equal cfg.my.minimum
+          chai.expect(state.ours.new_workers).to.equal cfg.ours.minimum
+          setWorkers1.done()
+          setWorkers2.done()
+          done()
+        governor.start()
+
   # Error cases
   describe 'Errors', ->
 

--- a/src/scale.coffee
+++ b/src/scale.coffee
@@ -10,7 +10,9 @@ common = require './common'
 proportional = (config, queueLength) ->
   # up to N concurrent jobs process in time P, but once N>C time becomes 2P, and so on
   waitingTime = Math.ceil(queueLength/config.concurrency)*config.processing
-  availableTime = config.target - config.processing
+  # availableTime should not get < config.processing, as we can never process a
+  # job faster than the mean processing time (on average).
+  availableTime = Math.max(config.processing, config.target - config.processing)
   return waitingTime/availableTime
 
 min = (a, b) -> if a < b then a else b


### PR DESCRIPTION
Fixes a conceptual error whereby it's assumed that process names are unique on heroku.
This can result in the wrong worker counts being used for the wrong config entries...
Note, includes https://github.com/flowhub/guv/pull/220...